### PR TITLE
feat: implementar endpoint PUT /auth/users/{userId}/role para cambiar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ pnpm start
 - `POST /auth/register` - Registrar nuevo usuario
 - `GET /auth/users` - Listar todos los usuarios
 - `PUT /auth/users/{userId}/status` - Activar/desactivar usuario
+- `PUT /auth/users/{userId}/role` - Cambiar rol de usuario
 
 ### 📦 Inventario
 
@@ -313,6 +314,62 @@ curl -X PUT http://localhost:3000/auth/users/{userId}/status \
 
 **Campos requeridos:**
 - `isActive` - Estado del usuario (true = activo, false = inactivo)
+
+### Cambiar Rol de Usuario (PUT /auth/users/{userId}/role)
+
+**⚠️ Solo administradores**
+
+```bash
+# Cambiar rol a administrador
+curl -X PUT http://localhost:3000/auth/users/{userId}/role \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "admin"
+  }'
+
+# Cambiar rol a usuario normal
+curl -X PUT http://localhost:3000/auth/users/{userId}/role \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "user"
+  }'
+```
+
+**Respuesta:**
+```json
+{
+  "success": true,
+  "message": "Rol actualizado exitosamente",
+  "user": {
+    "uid": "user123abc",
+    "email": "usuario@cemac.com",
+    "firstName": "Juan",
+    "lastName": "Pérez",
+    "role": "admin",
+    "isActive": true
+  }
+}
+```
+
+**Descripción:**
+- Solo usuarios con `role: 'admin'` pueden cambiar roles de otros usuarios
+- Actualiza el campo `role` en la base de datos y Firebase Auth custom claims
+- Un administrador **NO puede quitarse sus propios privilegios** (protección)
+- Se registra información de auditoría completa (quién, cuándo, rol anterior)
+- Los roles válidos son: `admin` y `user`
+
+**Validaciones:**
+- ✅ Solo administradores pueden acceder
+- ✅ El `userId` debe existir en la base de datos
+- ✅ El `role` debe ser "admin" o "user"
+- ✅ Un admin no puede quitarse sus propios privilegios
+- ✅ No se puede cambiar al mismo rol que ya tiene
+- ✅ Se actualiza tanto la DB como Firebase Auth custom claims
+
+**Campos requeridos:**
+- `role` - Nuevo rol del usuario ("admin" o "user")
 
 ### Obtener Perfil (GET /auth/profile)
 

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -6,7 +6,8 @@ const {
   getProfile, 
   updateProfile,
   getAllUsers,
-  updateUserStatus
+  updateUserStatus,
+  updateUserRole
 } = require('../controllers/authController');
 const { 
   authenticateUser, 
@@ -27,6 +28,7 @@ router.put('/profile', authenticateUser, updateProfile);
 router.post('/register', authenticateAdmin, register);
 router.get('/users', authenticateAdmin, getAllUsers);
 router.put('/users/:userId/status', authenticateAdmin, updateUserStatus);
+router.put('/users/:userId/role', authenticateAdmin, updateUserRole);
 
 // Ruta de prueba para verificar token
 router.get('/verify', authenticateUser, (req, res) => {


### PR DESCRIPTION
… rol de usuarios

- Agregar función updateUserRole() en authController.js
- Implementar validaciones: solo admins, roles válidos (admin/user), usuario debe existir
- Prevenir que admin se quite sus propios privilegios de administrador
- Validar que no se cambie al mismo rol que ya tiene el usuario
- Actualizar role en Firebase Realtime Database y custom claims de Firebase Auth
- Agregar información de auditoría completa (rol anterior, quién cambió, cuándo)
- Registrar ruta PUT /auth/users/:userId/role con middleware authenticateAdmin
- Actualizar documentación en README.md con ejemplos completos de uso
- Testear endpoint exitosamente: cambio admin<->user, validaciones y prevenciones